### PR TITLE
Propagate I/O errors when reading shell step output

### DIFF
--- a/src/workflow/executor.rs
+++ b/src/workflow/executor.rs
@@ -146,10 +146,20 @@ async fn execute_shell_step(
     let mut stderr = String::new();
 
     if let Some(ref mut out) = child.stdout {
-        out.read_to_string(&mut stdout).await.ok();
+        out.read_to_string(&mut stdout)
+            .await
+            .map_err(|e| StepExecutionError::ShellFailed {
+                message: format!("failed to read stdout: {}", e),
+                exit_code: None,
+            })?;
     }
     if let Some(ref mut err) = child.stderr {
-        err.read_to_string(&mut stderr).await.ok();
+        err.read_to_string(&mut stderr)
+            .await
+            .map_err(|e| StepExecutionError::ShellFailed {
+                message: format!("failed to read stderr: {}", e),
+                exit_code: None,
+            })?;
     }
 
     let status = child


### PR DESCRIPTION
Shell steps were using .ok() to discard I/O errors when reading stdout/stderr, causing read failures to be silently ignored. This fix propagates these errors via map_err, ensuring I/O failures are properly reported instead of resulting in empty output with false success. Fixes #1