### PR TITLE
perf: remove unnecessary JSON clone in output parser

### DIFF
--- a/src/backend_executor/output_parser.rs
+++ b/src/backend_executor/output_parser.rs
@@ -49,14 +49,13 @@ pub fn parse_output(text: &str, schema: Option<&OutputSchema>) -> ParsedOutput {
 
     // Try to extract JSON
     if let Some(json) = extract_json(text) {
-        output.json = Some(json.clone());
-
         // Validate against schema if provided
         if let Some(schema) = schema {
             let errors = validate_schema(&json, schema);
             output.schema_valid = Some(errors.is_empty());
             output.schema_errors = errors;
         }
+        output.json = Some(json);
     }
 
     output


### PR DESCRIPTION
extract_json() already returns an owned Value, no need to clone it before assigning to output.json. Reorder to validate before move.

Fixes #5