### PR TITLE
Kill and reap child process on read errors

### DIFF
--- a/src/workflow/executor.rs
+++ b/src/workflow/executor.rs
@@ -157,6 +157,7 @@ async fn execute_shell_step(
 
     if let Some(ref mut out) = child.stdout {
         if let Err(e) = out.read_to_string(&mut stdout).await {
+            let _ = child.kill().await;
             let exit_code = capture_exit_code(&mut child).await;
             return Err(StepExecutionError::ShellFailed {
                 message: format!("failed to read stdout: {}", e),
@@ -166,6 +167,7 @@ async fn execute_shell_step(
     }
     if let Some(ref mut err) = child.stderr {
         if let Err(e) = err.read_to_string(&mut stderr).await {
+            let _ = child.kill().await;
             let exit_code = capture_exit_code(&mut child).await;
             return Err(StepExecutionError::ShellFailed {
                 message: format!("failed to read stderr: {}", e),


### PR DESCRIPTION
execute_shell_step returns early on stdout/stderr read errors without calling child.wait(), leaving the spawned process as a zombie. The child is spawned at line 132 but the error paths at lines 148-163 use ? to return early, skipping the wait() call at line 165. Fixes #19