### PR TITLE
Kill and reap child processes on read errors

### DIFF
--- a/src/backend_executor/cli_backend.rs
+++ b/src/backend_executor/cli_backend.rs
@@ -205,7 +205,12 @@ impl BackendExecutor for CliBackend {
                     ))
                 }
             }
-            Ok(Err(e)) => Err(e),
+            Ok(Err(e)) => {
+                // Kill and reap child to prevent zombie process
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                Err(e)
+            }
             Err(_) => {
                 // Timeout - kill the process
                 let _ = child.kill().await;


### PR DESCRIPTION
## Summary
- Fixes zombie process leaks in `cli_backend.rs` and `verification.rs`
- Same pattern as #21 applied to remaining files

Fixes #22, #23

## Changes
- `cli_backend.rs`: Kill/wait child when async read block returns error
- `verification.rs`: Kill/wait child before returning OutputError on read failure

## Test plan
- [x] `cargo test` passes (211 tests)
- [x] `cargo build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)