### PR TITLE
Increase stderr line count in deadlock regression test

### DIFF
--- a/src/backend_executor/cli_backend.rs
+++ b/src/backend_executor/cli_backend.rs
@@ -316,7 +316,7 @@ mod tests {
             .with_timeout(Duration::from_secs(5));
 
         // Close stdout immediately, then write >64KB to stderr
-        let script = "exec >&-; for i in $(seq 1 2000); do echo \"stderr line $i\" >&2; done";
+        let script = "exec >&-; for i in $(seq 1 5000); do echo \"stderr line $i\" >&2; done";
         let request = BackendRequest::new(script);
 
         let result = backend.execute(&request).await;


### PR DESCRIPTION
The test writes 2,000 lines (~36KB) to stderr, which may not fill the 64KB Linux pipe buffer. If the buffer doesn't fill, the child process won't block and the deadlock scenario isn't properly exercised. Increasing to 5,000 lines (~90KB) ensures the buffer fills. Fixes #35