### PR TITLE
Extract capture_exit_code to shared process module

### DIFF
--- a/src/apply_and_verify/verification.rs
+++ b/src/apply_and_verify/verification.rs
@@ -5,7 +5,8 @@ use std::process::Stdio;
 use std::time::{Duration, Instant};
 use thiserror::Error;
 use tokio::io::AsyncReadExt;
-use tokio::process::{Child, Command};
+use crate::process::capture_exit_code;
+use tokio::process::Command;
 use tokio::time::timeout;
 
 /// Errors during verification
@@ -77,16 +78,6 @@ impl VerifyResult {
             output.push_str(&self.stderr);
         }
         output
-    }
-}
-
-/// Attempt to capture the exit code from a child process.
-/// Tries non-blocking first, falls back to blocking wait if process hasn't exited.
-async fn capture_exit_code(child: &mut Child) -> Option<i32> {
-    match child.try_wait() {
-        Ok(Some(status)) => status.code(),
-        Ok(None) => child.wait().await.ok().and_then(|status| status.code()),
-        Err(_) => None,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod apply_and_verify;
 mod backend_executor;
 mod cli;
 mod config;
+mod process;
 mod role;
 mod template;
 mod workflow;

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,13 @@
+//! Process utilities for child process management.
+
+use tokio::process::Child;
+
+/// Attempt to capture the exit code from a child process.
+/// Tries non-blocking first, falls back to blocking wait if process hasn't exited.
+pub(crate) async fn capture_exit_code(child: &mut Child) -> Option<i32> {
+    match child.try_wait() {
+        Ok(Some(status)) => status.code(),
+        Ok(None) => child.wait().await.ok().and_then(|status| status.code()),
+        Err(_) => None,
+    }
+}

--- a/src/workflow/executor.rs
+++ b/src/workflow/executor.rs
@@ -12,8 +12,9 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use thiserror::Error;
+use crate::process::capture_exit_code;
 use tokio::io::AsyncReadExt;
-use tokio::process::{Child, Command};
+use tokio::process::Command;
 
 /// Errors during step execution
 #[derive(Debug, Error)]
@@ -60,16 +61,6 @@ impl ExecutionContext {
             config,
             template_engine: TemplateEngine::new(),
         }
-    }
-}
-
-/// Attempt to capture the exit code from a child process.
-/// Tries non-blocking first, falls back to blocking wait if process hasn't exited.
-async fn capture_exit_code(child: &mut Child) -> Option<i32> {
-    match child.try_wait() {
-        Ok(Some(status)) => status.code(),
-        Ok(None) => child.wait().await.ok().and_then(|status| status.code()),
-        Err(_) => None,
     }
 }
 


### PR DESCRIPTION
The capture_exit_code async helper is duplicated verbatim in verification.rs and executor.rs. Both handle child process exit code capture with try_wait fallback to wait. Extracting to a shared module eliminates duplication and centralizes maintenance. Fixes #28