### PR TITLE
Add signal information to exit code capture

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -2,12 +2,30 @@
 
 use tokio::process::Child;
 
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
+
+/// Extract exit code from ExitStatus, using 128+signal for signal-terminated processes on Unix.
+fn exit_status_code(status: &std::process::ExitStatus) -> Option<i32> {
+    if let Some(code) = status.code() {
+        return Some(code);
+    }
+    #[cfg(unix)]
+    {
+        if let Some(signal) = status.signal() {
+            return Some(128 + signal);
+        }
+    }
+    None
+}
+
 /// Attempt to capture the exit code from a child process.
 /// Tries non-blocking first, falls back to blocking wait if process hasn't exited.
+/// On Unix, signal-terminated processes return 128 + signal number.
 pub(crate) async fn capture_exit_code(child: &mut Child) -> Option<i32> {
     match child.try_wait() {
-        Ok(Some(status)) => status.code(),
-        Ok(None) => child.wait().await.ok().and_then(|status| status.code()),
+        Ok(Some(status)) => exit_status_code(&status),
+        Ok(None) => child.wait().await.ok().and_then(|status| exit_status_code(&status)),
         Err(_) => None,
     }
 }


### PR DESCRIPTION
capture_exit_code uses ExitStatus::code() which returns None for signal-terminated processes. OOM kills (SIGKILL) and segfaults (SIGSEGV) show unhelpful 'exit code None' errors. Using ExitStatusExt on Unix allows reporting signal-based exit codes using the standard 128+signal convention.

Fixes #29