### PR TITLE
Apply signal-aware exit code handling to remaining status.code() calls

### DIFF
--- a/src/apply_and_verify/verification.rs
+++ b/src/apply_and_verify/verification.rs
@@ -5,7 +5,7 @@ use std::process::Stdio;
 use std::time::{Duration, Instant};
 use thiserror::Error;
 use tokio::io::AsyncReadExt;
-use crate::process::capture_exit_code;
+use crate::process::{capture_exit_code, exit_status_code};
 use tokio::process::Command;
 use tokio::time::timeout;
 
@@ -118,7 +118,7 @@ pub async fn run_verify(
     Ok(if status.success() {
         VerifyResult::success(stdout, stderr, duration)
     } else {
-        VerifyResult::failure(status.code(), stdout, stderr, duration)
+        VerifyResult::failure(exit_status_code(&status), stdout, stderr, duration)
     })
 }
 

--- a/src/backend_executor/cli_backend.rs
+++ b/src/backend_executor/cli_backend.rs
@@ -4,6 +4,7 @@
 
 use super::types::{BackendError, BackendExecutor, BackendRequest, BackendResponse};
 use crate::config::BackendConfig;
+use crate::process::exit_status_code;
 use async_trait::async_trait;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
@@ -200,7 +201,7 @@ impl BackendExecutor for CliBackend {
                     Ok(response)
                 } else {
                     Err(BackendError::execution_failed(
-                        status.code(),
+                        exit_status_code(&status),
                         stdout_text,
                         stderr_text,
                     ))

--- a/src/process.rs
+++ b/src/process.rs
@@ -6,7 +6,7 @@ use tokio::process::Child;
 use std::os::unix::process::ExitStatusExt;
 
 /// Extract exit code from ExitStatus, using 128+signal for signal-terminated processes on Unix.
-fn exit_status_code(status: &std::process::ExitStatus) -> Option<i32> {
+pub(crate) fn exit_status_code(status: &std::process::ExitStatus) -> Option<i32> {
     if let Some(code) = status.code() {
         return Some(code);
     }

--- a/src/workflow/executor.rs
+++ b/src/workflow/executor.rs
@@ -12,7 +12,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use thiserror::Error;
-use crate::process::capture_exit_code;
+use crate::process::{capture_exit_code, exit_status_code};
 use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 
@@ -213,7 +213,7 @@ async fn execute_shell_step(
         })
     } else {
         let error_msg = if stderr.is_empty() {
-            format!("command exited with code {:?}", status.code())
+            format!("command exited with code {:?}", exit_status_code(&status))
         } else {
             stderr.trim().to_string()
         };
@@ -231,7 +231,7 @@ async fn execute_shell_step(
         } else {
             Err(StepExecutionError::ShellFailed {
                 message: error_msg,
-                exit_code: status.code(),
+                exit_code: exit_status_code(&status),
             })
         }
     }


### PR DESCRIPTION
status.code() returns None for signal-terminated processes (OOM kills, segfaults, SIGINT, etc.), causing unhelpful error messages. The exit_status_code() helper already exists but is private. Making it pub(crate) and using it at all call sites ensures consistent 128+signal reporting on Unix. Fixes #41