### PR TITLE
Fix unused variable warning on non-Unix platforms

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -5,13 +5,13 @@ use tokio::process::Child;
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 
-fn exit_status_code_parts(code: Option<i32>, signal: Option<i32>) -> Option<i32> {
+fn exit_status_code_parts(code: Option<i32>, _signal: Option<i32>) -> Option<i32> {
     if let Some(code) = code {
         return Some(code);
     }
     #[cfg(unix)]
     {
-        if let Some(signal) = signal {
+        if let Some(signal) = _signal {
             return Some(128 + signal);
         }
     }


### PR DESCRIPTION
The `signal` parameter in `exit_status_code_parts` is only used within the `#[cfg(unix)]` block. On non-Unix platforms (Windows), this block is excluded during compilation, resulting in an unused variable warning. Prefixing with underscore tells the Rust compiler to suppress the warning while still allowing the variable to be used when the unix cfg is active. Fixes #49