### PR TITLE
Gate shell-dependent test with #[cfg(unix)]

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -68,6 +68,7 @@ mod tests {
         assert_eq!(exit_status_code_parts(None, Some(9)), None);
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_capture_exit_code() {
         let mut child = tokio::process::Command::new("sh")


### PR DESCRIPTION
The test_capture_exit_code test uses `sh -c "exit 42"` which requires a Unix shell. Windows CI fails because `sh` is not available. This matches the existing pattern used for the signal_exit_code test at line 54. Fixes #48