### PR TITLE
Add process reaping to verification.rs timeout handling

### DIFF
--- a/src/apply_and_verify/verification.rs
+++ b/src/apply_and_verify/verification.rs
@@ -105,6 +105,7 @@ pub async fn run_verify(
             Err(_) => {
                 // Kill the process on timeout
                 let _ = child.kill().await;
+                let _ = child.wait().await; // Reap the process
                 return Err(VerifyError::Timeout(dur));
             }
         }


### PR DESCRIPTION
Process timeout in verification.rs calls kill() but does not call wait() to reap the process. This leaves a zombie process in the process table until the parent exits. PR #52 established the correct pattern in executor.rs which should be applied here for consistency. Fixes #55