### PR TITLE
Extract wait_for_output to shared process module

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -40,20 +40,30 @@ pub(crate) async fn capture_exit_code(child: &mut Child) -> Option<i32> {
     }
 }
 
+/// Stream types for child processes.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum OutputStream {
+    /// Standard output stream.
     Stdout,
+    /// Standard error stream.
     Stderr,
 }
 
+/// Errors occurring while waiting for child process output.
 #[derive(Debug)]
 pub(crate) enum OutputWaitError {
+    /// Error reading from a stream.
     Read {
+        /// The stream where the error occurred.
         stream: OutputStream,
+        /// The underlying IO error.
         source: std::io::Error,
+        /// The exit code of the process if it has already exited.
         exit_code: Option<i32>,
     },
+    /// Error waiting for the process to exit.
     Wait {
+        /// The underlying IO error.
         source: std::io::Error,
     },
 }

--- a/src/workflow/executor.rs
+++ b/src/workflow/executor.rs
@@ -446,6 +446,7 @@ mod tests {
         ));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_execute_shell_timeout() {
         let config = Arc::new(create_test_config());
@@ -466,6 +467,7 @@ mod tests {
         assert!(matches!(result, Err(StepExecutionError::ShellTimeout(_))));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_execute_shell_timeout_continue_on_error() {
         let config = Arc::new(create_test_config());
@@ -490,6 +492,7 @@ mod tests {
         assert!(result.error.unwrap().contains("timed out"));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_execute_shell_timeout_success() {
         let config = Arc::new(create_test_config());


### PR DESCRIPTION
Both executor.rs and verification.rs have nearly identical functions for reading child process output concurrently with tokio::join!, killing the process on read errors, and capturing exit codes. This duplication risks inconsistent error handling and makes the codebase harder to maintain. Fixes #56