### PR TITLE
Fix zombie process on CLI backend timeout

### DIFF
--- a/src/backend_executor/cli_backend.rs
+++ b/src/backend_executor/cli_backend.rs
@@ -220,6 +220,7 @@ impl BackendExecutor for CliBackend {
             Err(_) => {
                 // Timeout - kill the process
                 let _ = child.kill().await;
+                let _ = child.wait().await; // Reap the process
                 let partial = if stdout_lines.is_empty() {
                     None
                 } else {


### PR DESCRIPTION
When a CLI backend execution times out in cli_backend.rs, the child process is killed but not reaped, leaving a zombie. The reported issue in verification.rs was already fixed, but the same pattern exists in the backend executor timeout handler. Fixes #62